### PR TITLE
Add "comment" (optional) parameter to list add function.

### DIFF
--- a/pihole/main.py
+++ b/pihole/main.py
@@ -203,10 +203,12 @@ class PiHole(object):
             "http://" + str(self.ip_address) + "/admin/api.php?list=" + list + "&auth=" + self.auth_data.token).json()
 
     @requires_auth
-    def add(self, list, domain):
-        requests.get(
-            "http://" + str(self.ip_address) + "/admin/api.php?list=" + list + "&add=" + domain + "&auth=" +
-            self.auth_data.token)
+    def add(self, list, domain, comment=""):
+        url = "/admin/api.php?list=" + list + "&add=" + domain + "&auth=" + self.auth_data.token
+        comment = {'comment': comment}
+        response = requests.post(
+            "http://" + str(self.ip_address) + url, data=comment)
+        return response.text
 
     @requires_auth
     def sub(self, list, domain):


### PR DESCRIPTION
Add "comment" (optional) parameter to list add function.
When you add a domain, it helps to distinguish between APIs and UIs based on comments

Motivation:
I have a list with domains I want to add to Pi-hole through API. Without comments when I open blocked domains on Pi-hole admin, comment for domains are empty. So I don't know what was added via admin site or API.

With this easy addition, we can add a comment to every domain.